### PR TITLE
Refactor exporter and retrying failed creates as update

### DIFF
--- a/exporter.sh
+++ b/exporter.sh
@@ -23,7 +23,7 @@ for row in "${ORGS[@]}" ; do
     for id in $(fetch_fields $KEY 'datasources' 'id'); do
         DS=$(echo $(fetch_fields $KEY "datasources/${id}" 'name')|sed 's/ /-/g').json
         echo $DS
-        curl -f -k -H "Authorization: Bearer ${KEY}" "${HOST}/api/datasources/${id}" | jq '.id = null' | jq '.orgId = null' > "$DIR/datasources/$DS"
+        curl -f -k -H "Authorization: Bearer ${KEY}" "${HOST}/api/datasources/${id}" | jq '.id = null' | jq '.orgId = null' > "$DIR/datasources/${id}.json"
     done
 
     for id in $(fetch_fields $KEY 'alert-notifications' 'id'); do

--- a/exporter.sh
+++ b/exporter.sh
@@ -17,18 +17,18 @@ for row in "${ORGS[@]}" ; do
     for dash in $(fetch_fields $KEY 'search?query=&' 'uri'); do
         DB=$(echo ${dash}|sed 's,db/,,g').json
         echo $DB
-        curl -f -k -H "Authorization: Bearer ${KEY}" "${HOST}/api/dashboards/${dash}" | jq '.dashboard.id = null' | jq '.overwrite = true' > "$DIR/dashboards/$DB"
+        curl -f -k -H "Authorization: Bearer ${KEY}" "${HOST}/api/dashboards/${dash}" | jq 'del(.overwrite,.dashboard.version,.meta.created,.meta.createdBy,.meta.updated,.meta.updatedBy,.meta.expires,.meta.version)' > "$DIR/dashboards/$DB"
     done
 
     for id in $(fetch_fields $KEY 'datasources' 'id'); do
         DS=$(echo $(fetch_fields $KEY "datasources/${id}" 'name')|sed 's/ /-/g').json
         echo $DS
-        curl -f -k -H "Authorization: Bearer ${KEY}" "${HOST}/api/datasources/${id}" | jq '.id = null' | jq '.orgId = null' > "$DIR/datasources/${id}.json"
+        curl -f -k -H "Authorization: Bearer ${KEY}" "${HOST}/api/datasources/${id}" | jq '' > "$DIR/datasources/${id}.json"
     done
 
     for id in $(fetch_fields $KEY 'alert-notifications' 'id'); do
         FILENAME=${id}.json
         echo $FILENAME
-        curl -f -k -H "Authorization: Bearer ${KEY}" "${HOST}/api/alert-notifications/${id}" > "$DIR/alert-notifications/$FILENAME"
+        curl -f -k -H "Authorization: Bearer ${KEY}" "${HOST}/api/alert-notifications/${id}" | jq 'del(.created,.updated)' > "$DIR/alert-notifications/$FILENAME"
     done
 done

--- a/importer.sh
+++ b/importer.sh
@@ -1,73 +1,84 @@
 #!/usr/bin/env bash
 . "$(dirname "$0")/config.sh"
 
-import_file(){
-    if ! [ -f "$1" ]
-    then
-        echo "$file not found."
+
+declare -aa ORGMAP
+for row in "${ORGS[@]}"; do
+    IFS=':' read -r -a values <<< "$row"
+    ORGMAP[${values[0]}]=${values[1]}
+done
+
+curl_wrap() {
+    FILE=$1
+    KEY=$2
+    URL=$3
+    HTTP_VERB=$4
+    [[ -z "$HTTP_VERB" ]] && HTTP_VERB=POST
+
+    curl --fail -k -X$HTTP_VERB \
+         -H "Content-Type: application/json" \
+         -H "Accept: application/json" \
+         -H "Authorization: Bearer $KEY" \
+         --data-binary @$FILE \
+         $URL
+}
+
+import_file() {
+    FILE="$1"
+    KEY="$2"
+    TYPE="$3"
+
+    if ! [ -f "$FILE" ]; then
+        echo "$FILE not found." >>/dev/stderr
         return
     fi
 
-    echo "Processing $1 file..."
-    curl -k -XPOST "${HOST}/api/$3" --data-binary @$1 -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer $2"
+    echo "Processing $FILE file..."
+    curl_wrap "$FILE" "$KEY" "${HOST}/api/$TYPE"
+    CURL_EXIT=$?
     echo
+
+    if [[ ${CURL_EXIT} = 22 && $TYPE = "datasources" ]]; then
+        echo "409 conflict error is normal. Retrying as update."
+        id=$(basename $file .json)
+        curl_wrap "$FILE" "$KEY" "${HOST}/api/$TYPE/$id" PUT
+    elif [[ ${CURL_EXIT} = 22 && $TYPE = "alert-notifications" ]]; then
+        echo "500 server error is normal. Retrying as update."
+        id=$(basename $file .json)
+        curl_wrap "$FILE" "$KEY" "${HOST}/api/$TYPE/$id" PUT
+    fi
 }
 
-if [[ -n "$1" ]]; then
-    for f in "$@"; do
-        IFS='/' read -r -a args <<< "$f"
-        if ! [ ${#args[@]} == 3 ]; then
-            echo "Wrong param $f. Must be `organization/type/file`"
-        fi
 
-        ARGORG=${args[0]}
-        if [ -d "$FILE_DIR/$ARGORG" ]; then
-            for row in "${ORGS[@]}"; do
-                ORG=${row%%:*}
-                if [ $ARGORG == $ORG ]; then
-                    KEY=${row#*:}
-                    TYPE=${args[1]}
-                    FILE=${args[2]}
-
-                    for file in $FILE_DIR/$ORG/$TYPE/$FILE; do
-                        if [ $TYPE == 'dashboards' ]; then
-                            import_file $file "$KEY" 'dashboards/db'
-                        else
-                            import_file $file "$KEY" 'datasources'
-                        fi
-                    done
-                fi
-            done
-        else
-            echo "$FILE_DIR/$ARGORG does not exist."
-        fi
-    done
+if [[ $# -eq 0 ]]; then
+    ARGS=(${FILE_DIR}/*/*/*.json)
 else
-    echo "Importing all"
-    for row in "${ORGS[@]}" ; do
-        ORG=${row%%:*}
-        KEY=${row#*:}
-        DIR="$FILE_DIR/$ORG"
-
-        echo "Datasources..."
-        for file in $DIR/datasources/*.json; do
-            import_file $file "$KEY" 'datasources'
-        done
-
-        echo "Alert notifications"
-        for file in $DIR/alert-notifications/*.json; do
-            id=$(basename $file .json)
-
-            # import_file uses POST, we need PUT here
-            # Only updating existing alert notifications is supported for now
-            echo "Processing ${file} file..."
-            curl -k -XPUT "${HOST}/api/alert-notifications/${id}" --data-binary @$file -H "Content-Type: application/json" -H "Accept: application/json" -H "Authorization: Bearer ${KEY}"
-            echo
-        done
-
-        echo "Dashboards..."
-        for file in $DIR/dashboards/*.json; do
-            import_file $file "$KEY" 'dashboards/db'
-        done
-    done
+    ARGS=("$@")
 fi
+
+for FILE in "${ARGS[@]}"; do
+
+    IFS='/' read -r -a args <<< "$FILE"
+    if [ ${#args[@]} -ne 4 ]; then
+        echo "Wrong param \"${FILE}\". Must be data/{organization}/{type}/{file}"
+    fi
+
+    KEY=${ORGMAP[${args[1]}]}
+    TYPE=${args[2]}
+    # FILE=${args[3]}
+
+    case $TYPE in
+    alert-notifications)
+        import_file $FILE "$KEY" 'alert-notifications'
+        ;;
+    dashboards)
+        import_file $FILE "$KEY" 'dashboards/db'
+        ;;
+    datasources)
+        import_file $FILE "$KEY" 'datasources'
+        ;;
+    *)
+        echo "Unknown type $TYPE"
+        ;;
+    esac
+done


### PR DESCRIPTION
Simplifies exporter with a single code path that handles both importing all and importing specific files, result has less duplication and simpler to follow/work with.

Also failed creation results in retry as update with $id